### PR TITLE
Wrapping text in the label

### DIFF
--- a/minesweeper.py
+++ b/minesweeper.py
@@ -288,20 +288,6 @@ def new_game():
 
 statusbar_padding = 5
 
-
-# Make sure that text in status bar is wrapped correctly
-def update_statusbar_wraplength(event):
-    statusbar_action['wraplength'] = (
-        int(canvas['width'])
-        + sidebar.winfo_reqwidth()
-        - statusbar_time.winfo_reqwidth()
-        - statusbar_count.winfo_reqwidth()
-        - 2*statusbar_padding
-    )
-
-root.bind('<Configure>', update_statusbar_wraplength)
-
-
 statusbar_frame = ttk.Frame(big_frame, padding=2, relief='sunken')
 statusbar_frame.pack(side="bottom", fill='x')
 
@@ -359,6 +345,20 @@ difficulty_slider.pack(padx=5)
 
 quit_game_button = ttk.Button(sidebar, text="Quit game", command=quit_game)
 quit_game_button.pack(fill="x", side="bottom", pady=10)
+
+
+# Make sure that text in status bar is wrapped correctly
+def update_statusbar_wraplength(event):
+    statusbar_action['wraplength'] = (
+        int(canvas['width'])
+        + sidebar.winfo_reqwidth()
+        - statusbar_time.winfo_reqwidth()
+        - statusbar_count.winfo_reqwidth()
+        - 2*statusbar_padding
+    )
+
+root.bind('<Configure>', update_statusbar_wraplength)
+
 
 new_game()
 root.title("Minesweeper – by Arrinao, The Philgrim, and Master Akuli")

--- a/minesweeper.py
+++ b/minesweeper.py
@@ -285,14 +285,31 @@ def new_game():
     statusbar_action["text"] = "***Lets go!***"
     statusbar_count["text"] = f"{current_game.how_many_mines_user_wants} mines left"
 
+
+statusbar_padding = 5
+
+
+# Make sure that text in status bar is wrapped correctly
+def update_statusbar_wraplength(event):
+    statusbar_action['wraplength'] = (
+        int(canvas['width'])
+        + sidebar.winfo_reqwidth()
+        - statusbar_time.winfo_reqwidth()
+        - statusbar_count.winfo_reqwidth()
+        - 2*statusbar_padding
+    )
+
+root.bind('<Configure>', update_statusbar_wraplength)
+
+
 statusbar_frame = ttk.Frame(big_frame, padding=2, relief='sunken')
 statusbar_frame.pack(side="bottom", fill='x')
 
 statusbar_time = ttk.Label(statusbar_frame)
 statusbar_time.pack(side='left')
 
-statusbar_action = ttk.Label(statusbar_frame, anchor='center', wraplength=200)
-statusbar_action.pack(side='left', fill='x', expand=True)
+statusbar_action = ttk.Label(statusbar_frame, anchor='center')
+statusbar_action.pack(side='left', padx=statusbar_padding, fill='x', expand=True)
 
 statusbar_count = ttk.Label(statusbar_frame)
 statusbar_count.pack(side='left', fill='x')

--- a/minesweeper.py
+++ b/minesweeper.py
@@ -288,13 +288,13 @@ def new_game():
 statusbar_frame = ttk.Frame(big_frame, padding=2, relief='sunken')
 statusbar_frame.pack(side="bottom", fill='x')
 
-statusbar_time = ttk.Label(statusbar_frame, anchor='w')
+statusbar_time = ttk.Label(statusbar_frame)
 statusbar_time.pack(side='left')
 
 statusbar_action = ttk.Label(statusbar_frame, anchor='center', wraplength=200)
 statusbar_action.pack(side='left', fill='x', expand=True)
 
-statusbar_count = ttk.Label(statusbar_frame, anchor='e')
+statusbar_count = ttk.Label(statusbar_frame)
 statusbar_count.pack(side='left', fill='x')
 
 sidebar = ttk.Frame(top_frame, borderwidth=2)

--- a/minesweeper.py
+++ b/minesweeper.py
@@ -351,8 +351,7 @@ quit_game_button.pack(fill="x", side="bottom", pady=10)
 # Make sure that text in status bar is wrapped correctly
 def update_statusbar_wraplength(event):
     statusbar_action['wraplength'] = (
-        int(canvas['width'])
-        + sidebar.winfo_reqwidth()
+        top_frame.winfo_reqwidth()
         - statusbar_time.winfo_reqwidth()
         - statusbar_count.winfo_reqwidth()
         - 15  # Leave gaps between the status bar labels

--- a/minesweeper.py
+++ b/minesweeper.py
@@ -291,7 +291,7 @@ statusbar_frame.pack(side="bottom", fill='x')
 statusbar_time = ttk.Label(statusbar_frame, anchor='w')
 statusbar_time.pack(side='left')
 
-statusbar_action = ttk.Label(statusbar_frame, anchor='center')
+statusbar_action = ttk.Label(statusbar_frame, anchor='center', wraplength=200)
 statusbar_action.pack(side='left', fill='x', expand=True)
 
 statusbar_count = ttk.Label(statusbar_frame, anchor='e')

--- a/minesweeper.py
+++ b/minesweeper.py
@@ -288,14 +288,14 @@ def new_game():
 statusbar_frame = ttk.Frame(big_frame, padding=2, relief='sunken')
 statusbar_frame.pack(side="bottom", fill='x')
 
-statusbar_time = ttk.Label(statusbar_frame, anchor='w', width='15')
-statusbar_time.pack(padx='10', side='left')
+statusbar_time = ttk.Label(statusbar_frame, anchor='w')
+statusbar_time.pack(side='left')
 
-statusbar_action = ttk.Label(statusbar_frame, anchor='center', wraplength=200)
+statusbar_action = ttk.Label(statusbar_frame, anchor='center')
 statusbar_action.pack(side='left', fill='x', expand=True)
 
-statusbar_count = ttk.Label(statusbar_frame, anchor='e', width='15')
-statusbar_count.pack(padx='15', side='left', fill='x')
+statusbar_count = ttk.Label(statusbar_frame, anchor='e')
+statusbar_count.pack(side='left', fill='x')
 
 sidebar = ttk.Frame(top_frame, borderwidth=2)
 sidebar.pack(side="right", fill="both", anchor="w")

--- a/minesweeper.py
+++ b/minesweeper.py
@@ -291,7 +291,7 @@ statusbar_frame.pack(side="bottom", fill='x')
 statusbar_time = ttk.Label(statusbar_frame, anchor='w', width='15')
 statusbar_time.pack(padx='10', side='left')
 
-statusbar_action = ttk.Label(statusbar_frame, anchor='center')
+statusbar_action = ttk.Label(statusbar_frame, anchor='center', wraplength=200)
 statusbar_action.pack(side='left', fill='x', expand=True)
 
 statusbar_count = ttk.Label(statusbar_frame, anchor='e', width='15')

--- a/minesweeper.py
+++ b/minesweeper.py
@@ -286,16 +286,17 @@ def new_game():
     statusbar_count["text"] = f"{current_game.how_many_mines_user_wants} mines left"
 
 
-statusbar_padding = 5
-
 statusbar_frame = ttk.Frame(big_frame, padding=2, relief='sunken')
 statusbar_frame.pack(side="bottom", fill='x')
+
+# Make sure that statusbar is always 2 lines tall
+ttk.Label(statusbar_frame, text='\n').pack(side='left')
 
 statusbar_time = ttk.Label(statusbar_frame)
 statusbar_time.pack(side='left')
 
 statusbar_action = ttk.Label(statusbar_frame, anchor='center')
-statusbar_action.pack(side='left', padx=statusbar_padding, fill='x', expand=True)
+statusbar_action.pack(side='left', padx=5, fill='x', expand=True)
 
 statusbar_count = ttk.Label(statusbar_frame)
 statusbar_count.pack(side='left', fill='x')
@@ -354,7 +355,7 @@ def update_statusbar_wraplength(event):
         + sidebar.winfo_reqwidth()
         - statusbar_time.winfo_reqwidth()
         - statusbar_count.winfo_reqwidth()
-        - 2*statusbar_padding
+        - 15  # Padding and some extra
     )
 
 root.bind('<Configure>', update_statusbar_wraplength)

--- a/minesweeper.py
+++ b/minesweeper.py
@@ -296,7 +296,7 @@ statusbar_time = ttk.Label(statusbar_frame)
 statusbar_time.pack(side='left')
 
 statusbar_action = ttk.Label(statusbar_frame, anchor='center')
-statusbar_action.pack(side='left', padx=5, fill='x', expand=True)
+statusbar_action.pack(side='left', fill='x', expand=True)
 
 statusbar_count = ttk.Label(statusbar_frame)
 statusbar_count.pack(side='left', fill='x')
@@ -355,7 +355,7 @@ def update_statusbar_wraplength(event):
         + sidebar.winfo_reqwidth()
         - statusbar_time.winfo_reqwidth()
         - statusbar_count.winfo_reqwidth()
-        - 15  # Padding and some extra
+        - 15  # Leave gaps between the status bar labels
     )
 
 root.bind('<Configure>', update_statusbar_wraplength)

--- a/minesweeper.py
+++ b/minesweeper.py
@@ -295,7 +295,7 @@ ttk.Label(statusbar_frame, text='\n').pack(side='left')
 statusbar_time = ttk.Label(statusbar_frame)
 statusbar_time.pack(side='left')
 
-statusbar_action = ttk.Label(statusbar_frame, anchor='center')
+statusbar_action = ttk.Label(statusbar_frame, anchor='center', justify='center')
 statusbar_action.pack(side='left', fill='x', expand=True)
 
 statusbar_count = ttk.Label(statusbar_frame)


### PR DESCRIPTION
Currently the text in the status bar label can be so long that the canvas becomes too wide:

![ss](https://user-images.githubusercontent.com/18505570/105614851-d9980280-5dd4-11eb-9892-691e756f2956.png)


This pull request is supposed to fix that, but it's not ready for merging yet.