### PR TITLE
slider fix

### DIFF
--- a/minesweeper.py
+++ b/minesweeper.py
@@ -344,6 +344,11 @@ difficulty_slider = ttk.LabeledScale(sidebar, from_=5, to=50, variable=slider_va
 difficulty_slider.value = 15
 difficulty_slider.pack(padx=5)
 
+# Tkinter's LabeledScale is broken: https://bugs.python.org/issue40219
+height_slider.label.lift()
+width_slider.label.lift()
+difficulty_slider.label.lift()
+
 quit_game_button = ttk.Button(sidebar, text="Quit game", command=quit_game)
 quit_game_button.pack(fill="x", side="bottom", pady=10)
 


### PR DESCRIPTION
Fixes #44

This is actually a bug in Python and not in our code, but it's still possible to make it work for the time being, without requiring everyone to update to a newer Python.

The problem is that `LabeledScale` creates a small label that is supposed to be invisible, but it ends up in front of the label that displays the numbers. This PR lifts the number label in front so that the small label gets hidden behind it.