### PR TITLE
speed up auto-opening

### DIFF
--- a/minesweeper.py
+++ b/minesweeper.py
@@ -22,7 +22,7 @@ class Game:
         self.height = height
         self.how_many_mines_user_wants = mine_count
         self.mine_locations = []
-        self.previously_clicked_square = []
+        self.previously_clicked_square = set()
         self.flag_dict = {}
         self.game_status = GameStatus.in_progress
 
@@ -69,7 +69,7 @@ class Game:
         if coordinate in self.previously_clicked_square or coordinate in self.flag_dict:
             return
 
-        self.previously_clicked_square.append((x, y))
+        self.previously_clicked_square.add((x, y))
         canvas.create_image(
             int(x * button_size),
             int(y * button_size),


### PR DESCRIPTION
In #57 I noticed that auto-opening was slow when width and height sliders are set to max and mine percentage slider is set to min. I temporarily added this code to time it:

```diff
         if len(current_game.mine_locations) == 0:
             current_game.generate_random_mine_locations(coordinate)
+        import time
+        start = time.time()
         current_game.open_squares(x, y)
+        end = time.time()
+        print(end - start)
 
 
 button_size = 23
```

On my system, this pull request roughly **halves** the amount of time needed, 0.37 seconds to 0.17 seconds.

`previously_clicked_square` contains many coordinates. In a 35x55 game, there are `35*55 = 1925` squares, and `previously_clicked_square` can easily contain more than half of them during auto-opening. With such a huge list, `if coordinate in self.previously_clicked_square` is very slow, since it has to go through all the items in the list to check if any of them match the `coordinate`. But sets are much better at this. Checking if an item is in a set is very fast, even with a huge set.