### PR TITLE
Fix broken builds and run them on pull request

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,9 +10,7 @@ jobs:
     - uses: actions/checkout@v1
     - run: brew install python@3.9    # https://github.com/actions/setup-python/issues/58
     # TODO: is it possible to use a newer pyinstaller?
-    # --no-use-pep517 is to prevent pyproject.toml error when installing old pyinstaller.
-    - run: pip3 install --no-use-pep517 pyinstaller==4.10
-    - run: pip3 install appdirs
+    - run: pip3 install pyinstaller==4.10 appdirs
     - run: pyinstaller --add-data 'images:.' --windowed --icon images/bomb.png minesweeper.py
     - run: hdiutil create Minesweeper.dmg -volname "Minesweeper" -srcfolder dist/minesweeper.app
     - uses: actions/upload-artifact@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     - run: brew install python@3.9    # https://github.com/actions/setup-python/issues/58
     # TODO: is it possible to use a newer pyinstaller?
     # --no-use-pep517 is to prevent pyproject.toml error when installing old pyinstaller.
-    - run: pip3 install --no-use-pep517 pyinstaller==4.3
+    - run: pip3 install --no-use-pep517 pyinstaller==4.10
     - run: pip3 install appdirs
     - run: pyinstaller --add-data 'images:.' --windowed --icon images/bomb.png minesweeper.py
     - run: hdiutil create Minesweeper.dmg -volname "Minesweeper" -srcfolder dist/minesweeper.app

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - run: brew install python@3.9    # https://github.com/actions/setup-python/issues/58
-    - run: pip3 install pyinstaller appdirs
+    - run: pip3 install pyinstaller==4.2 appdirs
     - run: pyinstaller --add-data 'images:.' --windowed --icon images/bomb.png minesweeper.py
     - run: hdiutil create Minesweeper.dmg -volname "Minesweeper" -srcfolder dist/minesweeper.app
     - uses: actions/upload-artifact@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,6 +40,7 @@ jobs:
         name: windows-exe
         path: dist/minesweeper.exe
   release:
+    # Skip this step on pull requests.
     if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
     needs: [mac_build, windows_build]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,7 @@ on:
   push:
     branches:
       - main
+  pull_request:
 jobs:
   mac_build:
     runs-on: macos-latest
@@ -35,6 +36,7 @@ jobs:
         name: windows-exe
         path: dist/minesweeper.exe
   release:
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
     needs: [mac_build, windows_build]
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     - run: brew install python@3.9    # https://github.com/actions/setup-python/issues/58
     # TODO: is it possible to use a newer pyinstaller?
     # --no-use-pep517 is to prevent pyproject.toml error when installing old pyinstaller.
-    - run: pip3 install --no-use-pep517 pyinstaller==4.2
+    - run: pip3 install --no-use-pep517 pyinstaller==4.3
     - run: pip3 install appdirs
     - run: pyinstaller --add-data 'images:.' --windowed --icon images/bomb.png minesweeper.py
     - run: hdiutil create Minesweeper.dmg -volname "Minesweeper" -srcfolder dist/minesweeper.app

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,10 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - run: brew install python@3.9    # https://github.com/actions/setup-python/issues/58
-    - run: pip3 install pyinstaller==4.2 appdirs
+    # TODO: is it possible to use a newer pyinstaller?
+    # --no-use-pep517 is to prevent pyproject.toml error when installing old pyinstaller.
+    - run: pip3 install --no-use-pep517 pyinstaller==4.2
+    - run: pip3 install appdirs
     - run: pyinstaller --add-data 'images:.' --windowed --icon images/bomb.png minesweeper.py
     - run: hdiutil create Minesweeper.dmg -volname "Minesweeper" -srcfolder dist/minesweeper.app
     - uses: actions/upload-artifact@v2
@@ -29,7 +32,10 @@ jobs:
     - uses: ilammy/msvc-dev-cmd@v1
     - run: git clone --depth=1 https://github.com/pyinstaller/pyinstaller --branch v4.2
     - run: cd pyinstaller/bootloader && python ./waf all
-    - run: pip install ./pyinstaller appdirs
+    # TODO: is it possible to use a newer pyinstaller?
+    # --no-use-pep517 is to prevent pyproject.toml error when installing old pyinstaller.
+    - run: pip install --no-use-pep517 ./pyinstaller
+    - run: pip install appdirs
     - run: pyinstaller --onefile --add-data 'images;.' minesweeper.py
     - uses: actions/upload-artifact@v2
       with:


### PR DESCRIPTION
Running the build on pull request (without the release step) is good for a few reasons:
- It is possible to test whether the build works without making a release.
- We will notice earlier if the builds break.
- A broken build can be fixed without pushing many small commits directly to main.

It does have one downside too: the build is slower than running `black`, so you will need to wait longer after pushing a commit to your pull request.